### PR TITLE
[Sikkerhet] Oppdaterer beskrivelse.yaml fra versjon 1.0 til 3.0 og oppretter catalog-info.yaml

### DIFF
--- a/.sikkerhet/beskrivelse.yaml
+++ b/.sikkerhet/beskrivelse.yaml
@@ -1,2 +1,5 @@
-version: 1.0
-organisasjon: IT
+version: 3.0
+organization: IT
+product: Digitaltvilling
+repo_types: [Documentation]
+platforms: []

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,37 @@
+# nonk8s
+apiVersion: "backstage.io/v1alpha1"
+kind: "Component"
+metadata:
+  name: "digitaltvillinger.github.io"
+  tags:
+  - "public"
+spec:
+  type: "documentation"
+  lifecycle: "production"
+  owner: "datadeling_og_distribusjon"
+---
+apiVersion: "backstage.io/v1alpha1"
+kind: "Group"
+metadata:
+  name: "security_champion_digitaltvillinger.github.io"
+  title: "Security Champion digitaltvillinger.github.io"
+spec:
+  type: "security_champion"
+  parent: "land_security_champions"
+  members:
+  - "tevbrasch"
+  children:
+  - "resource:digitaltvillinger.github.io"
+---
+apiVersion: "backstage.io/v1alpha1"
+kind: "Resource"
+metadata:
+  name: "digitaltvillinger.github.io"
+  links:
+  - url: "https://github.com/kartverket/digitaltvillinger.github.io"
+    title: "digitaltvillinger.github.io på GitHub"
+spec:
+  type: "repo"
+  owner: "security_champion_digitaltvillinger.github.io"
+  dependencyOf:
+  - "component:digitaltvillinger.github.io"


### PR DESCRIPTION
Denne PRen oppdaterer `.sikkerhet/beskrivelse.yaml` til versjon 3.0. Det innebærer at feltene nå blir på engelsk i stedet for norsk. Følgende felter legges inn:

- `version: 3.0`
- `organization: IT`
- `product: Digitaltvilling`
- `repo_types: [Documentation]`
- `platforms: []`

Videre oppdaterer denne PRen `catalog-info.yaml` for å gi entiteter til Backstage.

Det er beskrevet [her i Sikkerhetshåndboka](https://kartverket.atlassian.net/wiki/spaces/SIK/pages/732397586/Sikkerhet+i+repoet) hvorfor vi gjør dette.