### PR TITLE
[Sikkerhet] Oppdaterer med ny catalog-info.yaml og engelske filnavn

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-/.sikkerhet/ @tevbrasch
+/.security/ @tevbrasch

--- a/.security/description.yaml
+++ b/.security/description.yaml
@@ -1,4 +1,3 @@
-version: 3.0
 organization: IT
 product: Digitaltvilling
 repo_types: [Documentation]

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -9,29 +9,3 @@ spec:
   type: "documentation"
   lifecycle: "production"
   owner: "datadeling_og_distribusjon"
----
-apiVersion: "backstage.io/v1alpha1"
-kind: "Group"
-metadata:
-  name: "security_champion_digitaltvillinger.github.io"
-  title: "Security Champion digitaltvillinger.github.io"
-spec:
-  type: "security_champion"
-  parent: "land_security_champions"
-  members:
-  - "tevbrasch"
-  children:
-  - "resource:digitaltvillinger.github.io"
----
-apiVersion: "backstage.io/v1alpha1"
-kind: "Resource"
-metadata:
-  name: "digitaltvillinger.github.io"
-  links:
-  - url: "https://github.com/kartverket/digitaltvillinger.github.io"
-    title: "digitaltvillinger.github.io på GitHub"
-spec:
-  type: "repo"
-  owner: "security_champion_digitaltvillinger.github.io"
-  dependencyOf:
-  - "component:digitaltvillinger.github.io"


### PR DESCRIPTION
Denne PRen oppdaterer `catalog-info.yaml` for å gi entiteter til Backstage. Vi fjerner nå resource og sec. champ hierarkiet. Videre dropper vi å ha versionsnummer i description.yaml